### PR TITLE
Handle missing templates when rendering custom errors

### DIFF
--- a/lib/gaffe/errors.rb
+++ b/lib/gaffe/errors.rb
@@ -9,7 +9,11 @@ module Gaffe
     end
 
     def show
-      render "errors/#{@rescue_response}", status: @status_code
+      begin
+        render "errors/#{@rescue_response}", status: @status_code
+      rescue ActionView::MissingTemplate
+        render "errors/internal_server_error", status: 500
+      end
     end
 
   protected

--- a/spec/gaffe/errors_spec.rb
+++ b/spec/gaffe/errors_spec.rb
@@ -5,13 +5,28 @@ describe Gaffe::Errors do
     describe :show do
       let(:request) { ActionDispatch::TestRequest.new }
       let(:env) { request.env.merge 'action_dispatch.exception' => exception }
-      let(:exception) { ActionController::RoutingError.new(:foo) }
 
       let(:response) { Gaffe.errors_controller_for_request(env).action(:show).call(env) }
       subject { response.last }
 
-      its(:status) { should eql 404 }
-      its(:body) { should match /Not Found/ }
+      context 'with builtin exception' do
+        let(:exception) { ActionController::RoutingError.new(:foo) }
+        its(:status) { should eql 404 }
+        its(:body) { should match /Not Found/ }
+      end
+
+      context 'with custom exception and missing view' do
+        before { ActionDispatch::ExceptionWrapper.rescue_responses.merge! exception_class.name => 'my_custom_error' }
+
+        let(:exception_class) do
+          Object.instance_eval { remove_const :MyCustomError } if Object.const_defined?(:MyCustomError)
+          MyCustomError = Class.new(StandardError)
+        end
+
+        let(:exception) { exception_class.new }
+        its(:status) { should eql 500 }
+        its(:body) { should match /Internal Server Error/ }
+      end
     end
   end
 end


### PR DESCRIPTION
If the user has defined a custom exception bound to a custom `rescue_response` and the view cannot be found in their application (and because it’s obviously not found in Gaffe) we want to catch that and throw the default `internal_server_error` page, instead of Rails’ failsafe no-style error page.
