### PR TITLE
Try to call #constantize on errors_controller

### DIFF
--- a/lib/gaffe.rb
+++ b/lib/gaffe.rb
@@ -39,7 +39,9 @@ module Gaffe
       controller = controller.detect { |pattern, _| env["REQUEST_URI"] =~ pattern }.try(:last)
     end
 
-    controller || builtin_errors_controller
+    controller ||= builtin_errors_controller
+
+    controller.respond_to?(:constantize) ? controller.constantize : controller
   end
 
   # Return the root path of the gem

--- a/spec/gaffe/gaffe_spec.rb
+++ b/spec/gaffe/gaffe_spec.rb
@@ -30,6 +30,16 @@ describe Gaffe do
         it { expect(controller).to eql :foo }
       end
 
+      context 'with custom-defined controller that respond to `#constantize`' do
+        before do
+          Gaffe.configure do |config|
+            config.errors_controller = "String"
+          end
+        end
+
+        it { expect(controller).to eql String }
+      end
+
       context 'with multiple custom-defined controllers' do
         before do
           Gaffe.configure do |config|


### PR DESCRIPTION
Sometimes we want to call this code:

``` ruby
Gaffe.configure do |config|
  config.errors_controller = ErrorsController
end

Gaffe.enable!
```

But starting Rails might fail because auto-loading `ErrorsController`  this soon could raise exceptions because other initializers might be needed first.

So we can now to this:

``` ruby
Gaffe.configure do |config|
  config.errors_controller = 'ErrorsController'
end

Gaffe.enable!
```

And `"ErrorsController"` will be converted to its constant when we need it.
