### PR TITLE
Display original exception in test mode

### DIFF
--- a/app/assets/stylesheets/errors.css
+++ b/app/assets/stylesheets/errors.css
@@ -72,7 +72,7 @@ pre {
 }
 
 pre.exception {
-  background-color: #FFEDED;
+  background-color: #ffeded;
 }
 
 pre em {

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -18,8 +18,8 @@
         <hr>
       </div>
 
-      <% if Rails.env.test? %>
-        <p>Original exception (only displayed in <strong>test</strong> environment):</p>
+      <% if Rails.env.development? || Rails.env.test? %>
+        <p>Original exception (only displayed in <strong>development</strong> and <strong>test</strong> environment):</p>
 
 <pre>
 <code><%= @exception.inspect %></code>


### PR DESCRIPTION
This is very useful when running specs with `config.consider_all_requests_local = false` `config.action_dispatch.show_exceptions = true`: this displays the "real" error message that is also displayed to the user in production mode. To make debugging failing specs easier, displaying the original exception is very useful.

I don't know how to test this. If you want tests, please give me some information on how to approach this.

Thank you! :+1: 
