### PR TITLE
Upgrade to RSpec to 3.0.0 and update syntax

### DIFF
--- a/gaffe.gemspec
+++ b/gaffe.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'rspec', '3.0.0'
   spec.add_development_dependency 'coveralls'
 
   spec.add_development_dependency 'rubocop', '>= 0.21'

--- a/spec/gaffe/errors_spec.rb
+++ b/spec/gaffe/errors_spec.rb
@@ -6,13 +6,12 @@ describe Gaffe::Errors do
       let(:request) { ActionDispatch::TestRequest.new }
       let(:env) { request.env.merge 'action_dispatch.exception' => exception }
 
-      let(:response) { Gaffe.errors_controller_for_request(env).action(:show).call(env) }
-      subject { response.last }
+      let(:response) { Gaffe.errors_controller_for_request(env).action(:show).call(env).last }
 
       context 'with builtin exception' do
         let(:exception) { ActionController::RoutingError.new(:foo) }
-        its(:status) { should eql 404 }
-        its(:body) { should match(/Not Found/) }
+        it { expect(response.status).to eql 404 }
+        it { expect(response.body).to match(/Not Found/) }
       end
 
       context 'with custom exception and missing view' do
@@ -24,8 +23,8 @@ describe Gaffe::Errors do
         end
 
         let(:exception) { exception_class.new }
-        its(:status) { should eql 500 }
-        its(:body) { should match(/Internal Server Error/) }
+        it { expect(response.status).to eql 500 }
+        it { expect(response.body).to match(/Internal Server Error/) }
       end
     end
   end

--- a/spec/gaffe/gaffe_spec.rb
+++ b/spec/gaffe/gaffe_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Gaffe do
   describe :ClassMethods do
     describe :configure do
-      subject { Gaffe.configuration }
+      let(:configuration) { Gaffe.configuration }
       before do
         Gaffe.configure do |config|
           config.foo = :bar
@@ -11,8 +11,8 @@ describe Gaffe do
         end
       end
 
-      its(:foo) { should eql :bar }
-      its(:bar) { should eql :foo }
+      it { expect(configuration.foo).to eql :bar }
+      it { expect(configuration.bar).to eql :foo }
     end
 
     describe :errors_controller_for_request do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,12 +8,18 @@ require 'action_controller/railtie'
 require 'gaffe'
 
 RSpec.configure do |config|
+  # Disable `should` syntax
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
   config.before(:each) do
     # Fake Rails.root
-    Rails.stub(:root).and_return(RAILS_ROOT)
+    allow(Rails).to receive(:root).and_return(RAILS_ROOT)
 
     # Fake Rails.application
-    Rails.stub(:application).and_return OpenStruct.new(config: OpenStruct.new, env_config: {})
+    application = double('Rails Application', config: OpenStruct.new, env_config: {})
+    allow(Rails).to receive(:application).and_return(application)
 
     # Make sure we clear memoized variables before each test
     [:@configuration].each do |variable|


### PR DESCRIPTION
Time to move away from RSpec 2.14 and its `its`/`should` syntax!

![](http://www.painlesscooking.com/images/emmental-cheese.jpg)
