### PR TITLE
Root from ActionController::Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-version
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/gaffe/errors_controller.rb
+++ b/lib/gaffe/errors_controller.rb
@@ -1,5 +1,5 @@
 module Gaffe
-  class ErrorsController < ::ApplicationController
+  class ErrorsController < ::ActionController::Base
     include Errors
   end
 end


### PR DESCRIPTION
Use ::ActionController::Base instead of ::ApplicationController. 
Because it cause errors at before/after/around filter matchers within ApplicationController, like `before_filter :lalala, if: :some_case?`, when exception in `some_case?`.