### PR TITLE
RSpec configuration for error features

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ they do not go through the entire Rack stack to simulate a real HTTP request.
 
 To test responses sent by Gaffe, you must use *request tests*.
 
+### RSpec automatic configuration
+
+Alternatively you can require `gaffe/rspec` in your `spec(|rails)_helper` to selectively
+allow error pages rendering in rspec features.
+
+```ruby
+# spec/rails_helper.rb
+require 'gaffe/rspec'
+# spec/features/whatever_spec.rb
+RSpec.feature 'Error pages', :with_error_pages do
+  scenario 'Visit non existing pages' do
+    visit '/no-such-path'
+    expect(page).to have_title 'Not Found'
+    expect(page).to have_content 'The page you were looking for does not exist'
+  end
+end
+```
+
 ## Contributors
 
 * [@remiprev](https://github.com/remiprev)

--- a/lib/gaffe/rspec.rb
+++ b/lib/gaffe/rspec.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+
+  # Allow to write feature specs for dynamic error pages
+  config.around :each, :with_error_pages, type: :feature do |example|
+    begin
+      # Ensure that rails will render error pages when an error occurs
+      old, values = Rails.application.config.consider_all_requests_local, Rails.application.config.action_dispatch.show_exceptions
+      Rails.application.config.consider_all_requests_local = false
+      Rails.application.config.action_dispatch.show_exceptions = true
+      example.call # Run the example
+    ensure
+      # Restore old values
+      Rails.application.config.consider_all_requests_local = old
+      Rails.application.config.action_dispatch.show_exceptions = values
+    end
+  end
+
+end


### PR DESCRIPTION
This utility file will allow rspec users to write error page features with just a require and a tag in their features.

Let me know if it's fine.