### PR TITLE
Fix rails 5 deprication warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 rvm:
+  - 2.3.0
   - 2.1
   - 2.0
   - 1.9.3
@@ -11,10 +12,20 @@ gemfile:
   - gemfiles/Gemfile.rails-4.2
   - gemfiles/Gemfile.rails-4.0
   - gemfiles/Gemfile.rails-3.2.x
+  - gemfiles/Gemfile.rails-5.0
 
 script:
   - 'echo "Checking code style" && bundle exec phare'
   - 'echo "Running specs" && bundle exec rake spec'
+
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails-5.0
+    - rvm: 2.0
+      gemfile: gemfiles/Gemfile.rails-5.0
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile.rails-5.0
 
 notifications:
   hipchat:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ class ErrorsController < ApplicationController
   include Gaffe::Errors
 
   # Make sure anonymous users can see the page
-  skip_before_filter :authenticate_user!
+  skip_before_action :authenticate_user!
 
   # Override 'error' layout
   layout 'application'
@@ -97,7 +97,7 @@ class API::ErrorsController < API::ApplicationController
   include Gaffe::Errors
 
   # Make sure anonymous users can see the page
-  skip_before_filter :authenticate_user!
+  skip_before_action :authenticate_user!
 
   # Disable layout (your `API::ApplicationController` probably does this already)
   layout false

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '>= 5.0.0.beta2', '< 5.1'

--- a/lib/gaffe/errors.rb
+++ b/lib/gaffe/errors.rb
@@ -3,8 +3,13 @@ module Gaffe
     extend ActiveSupport::Concern
 
     included do
-      before_filter :fetch_exception, only: %w(show)
-      before_filter :append_view_paths
+      if Rails::VERSION::MAJOR >= 5
+        before_action :fetch_exception, only: %w(show)
+        before_action :append_view_paths
+      else
+        before_filter :fetch_exception, only: %w(show)
+        before_filter :append_view_paths
+      end
       layout 'error'
     end
 
@@ -17,8 +22,8 @@ module Gaffe
   protected
 
     def fetch_exception
-      @exception = env['action_dispatch.exception']
-      @status_code = ActionDispatch::ExceptionWrapper.new(env, @exception).status_code
+      @exception = request.env['action_dispatch.exception']
+      @status_code = ActionDispatch::ExceptionWrapper.new(request.env, @exception).status_code
       @rescue_response = ActionDispatch::ExceptionWrapper.rescue_responses[@exception.class.name]
     end
 

--- a/lib/gaffe/version.rb
+++ b/lib/gaffe/version.rb
@@ -1,3 +1,3 @@
 module Gaffe
-  VERSION = '1.0.2'
+  VERSION = '1.0.2'.freeze
 end

--- a/spec/gaffe/errors_controller_resolver_spec.rb
+++ b/spec/gaffe/errors_controller_resolver_spec.rb
@@ -4,7 +4,7 @@ describe Gaffe::ErrorsControllerResolver do
   describe :resolved_controller do
     let(:resolver) { Gaffe::ErrorsControllerResolver.new(env) }
     let(:controller) { resolver.resolved_controller }
-    let(:request) { ActionDispatch::TestRequest.new }
+    let(:request) { test_request }
     let(:env) { request.env }
 
     context 'with custom-defined controller' do

--- a/spec/gaffe/errors_spec.rb
+++ b/spec/gaffe/errors_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Gaffe::Errors do
   describe :Actions do
     describe :show do
-      let(:request) { ActionDispatch::TestRequest.new }
+      let(:request) { test_request }
       let(:env) { request.env.merge 'action_dispatch.exception' => exception }
       let(:status) { response.first }
       let(:body) { response.last.body }

--- a/spec/gaffe/gaffe_spec.rb
+++ b/spec/gaffe/gaffe_spec.rb
@@ -16,7 +16,7 @@ describe Gaffe do
     end
 
     describe :enable! do
-      let(:env) { ActionDispatch::TestRequest.new.env }
+      let(:env) { test_request }
       let(:action_double) { double(call: proc { [400, {}, 'SOMETHING WENT WRONG.'] }) }
       before { Gaffe.enable! }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,19 @@ end
 
 # We need a fake "ApplicationController" because Gaffe's default controller inherits from it
 class ApplicationController < ActionController::Base
+  if Rails::VERSION::MAJOR < 4
+    def self.before_action(*args)
+      before_filter(*args)
+    end
+  end
+end
+
+def test_request
+  if Rails::VERSION::MAJOR >= 5
+    ActionDispatch::TestRequest.create
+  else
+    ActionDispatch::TestRequest.new
+  end
 end
 
 # We need Rails.root


### PR DESCRIPTION
Fix these annoying deprecation warnings:
```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from get at /home/oleg/.rbenv/versions/2.3.0/lib64/ruby/2.3.0/forwardable.rb:184)
DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1. (called from get at /home/oleg/.rbenv/versions/2.3.0/lib64/ruby/2.3.0/forwardable.rb:184)
```

